### PR TITLE
Upgrade Rabbitmq to 3.8

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.6-management
+FROM rabbitmq:3.8-management
 
 ADD rabbitmq.config /etc/rabbitmq/
 ADD definitions.json /etc/rabbitmq/


### PR DESCRIPTION
The new production environment uses RabbitMQ 3.8.2.