### PR TITLE
LPD-15905 Upgrade deprecated actions to Node 20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Update Hosts file
         run: sudo sed -i '/^127.0.0.1/ s/$/ test.localhost/' /etc/hosts
       - run: docker-compose up -d


### PR DESCRIPTION
Actions using Node 16 are deprecated and should be updated to Node 20 actions.