### PR TITLE
LPD-18031 Use a real domain name while developing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The Docker Compose file in this repository contains an instance of
 [Traefik](https://traefik.io/) for development purposes. It allows you to access
 microservices through your browser using a hostname (such as
-`accounts.leviy.test`) and to run multiple microservices at the same time
+`accounts.test.leviy.com`) and to run multiple microservices at the same time
 without port binding conflicts.
 
 ## Getting started
@@ -16,7 +16,6 @@ without port binding conflicts.
 
 - [Docker](https://docs.docker.com/install/)
 - [Docker Compose](https://docs.docker.com/compose/)
-- A DNS resolver that resolves any hostname ending in ".test" to 127.0.0.1 (see [instructions](docs/dns.md))
 
 ### Installation
 
@@ -50,22 +49,25 @@ services:
     networks:
       - workspace
       - default
+
     labels:
-      traefik.frontend.rule: Host:subdomain.leviy.test
-      traefik.enable: 'true'
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.microservice-name.rule=Host(`microservice-name.test.leviy.com`)"
+    networks:
+      traefik-public:
+        aliases:
+          - microservice-name.test.leviy.com
 
 networks:
-  workspace:
-    external:
-      name: workspace_default
+  traefik-public:
+    external: true
 ```
 
-Web server services that should be reverse proxied should be linked to both the
-`workspace` network and the `default` network of that Docker Compose project.
-Non-web services (such as databases, etc.) should only be linked to the
-`default` network.
+Services that need to access the workspace for either reverse proxying or to access any of the services provided by it should be
+put in the `traefik-public` network.
 
 When started, Traefik will automatically detect this service and start routing
 traffic to it.
-To see it in action simply open `http://subdomain.leviy.test` in a
+To see it in action simply open `http://microservice-name.test.leviy.com` in a
 browser.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # Leviy Workspace
 
-[![Build Status](https://travis-ci.com/leviy/workspace.svg?token=gMER3s1tPFa8FEEFhAM4&branch=master)](https://travis-ci.com/leviy/workspace)
-
 The Docker Compose file in this repository contains an instance of
 [Traefik](https://traefik.io/) for development purposes. It allows you to access
 microservices through your browser using a hostname (such as

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -1,22 +1,12 @@
 # Configuring DNS
 
-Traefik routes traffic that matches the hostname of a Docker service's 
-`traefik.frontend.rule` label. However, for applications running on your host
-machine (curl, wget, the browser, etc.) to be able to know where to find the
-host you need to configure your DNS to resolve all hostnames ending on
-".localhost" to your local IP address.
+traefik routes traffic that matches the hostname of a Docker service's
+that is configured using the appropiate labels for traefik.
 
-## Linux (Ubuntu)
+We use service names like `<service>.test.leviy.com`. For this to work we've added the following A record to our leviy.com DNS.
 
-On Ubuntu 20.04 you have to manually add lines to the /etc/hosts file for all domains that
-you want to resolve locally:
+| Type | Name              | Value     | TTL |
+|------|-------------------|-----------|-----|
+| A    | *.test.leviy.com  | 127.0.0.1 | 300 |
 
-```
-127.0.0.1	dashboard.leviy.test
-127.0.0.1	files.leviy.test
-127.0.0.1	accounts.leviy.test
-```
-
-On Ubuntu 24.04 you can use the `systemd-resolve` to resolve all domains ending on ".test" to 127.0.0.1.
-
-(work in progress, will add additional instructions as soon as we updated to Ubuntu 24.04)
+No changes are needed to developer machines.


### PR DESCRIPTION
With the *.leviy.test domain everyone has to set up correct dns
masquerading configuration. Using a real dns wildcard domain no extra
configuration is required by the developers.

Also it is really hard if not even impossible to configure the *.leviy.test
domain correctly on android devices. Thus with leviy.test testing with a
real android device against the development dashboard was not possible
anymore.

Related to changes in https://github.com/leviy/workspace/pull/15